### PR TITLE
Fixes for behavior when a container is supplied

### DIFF
--- a/src/embedded.js
+++ b/src/embedded.js
@@ -651,7 +651,7 @@
                 var source = evt.source || 'hsEmbeddedFrame';
 
                 // DOM elements cannot be stringified; regular elements resolve to {}, React elements throw errors
-                const safeParams = Object.keys(params).reduce((safe, key) => {
+                var safeParams = Object.keys(params).reduce(function(safe, key) {
                    safe[key] = key !== 'container' ? params[key] : (params[key].id || params[key].tagName);
                    return safe;
                 }, {});
@@ -859,8 +859,8 @@
             var windowWidth = window.innerWidth;
             var windowHeight = window.innerHeight;
 
-            const screenWidthString = !this.isInPage ? screenWidth + 'px' : '100%';
-            const windowWidthString = !this.isInPage ? windowWidth + 'px' : '100%';
+            var screenWidthString = !this.isInPage ? screenWidth + 'px' : '100%';
+            var windowWidthString = !this.isInPage ? windowWidth + 'px' : '100%';
 
             var isPortrait = windowHeight > windowWidth;
 


### PR DESCRIPTION
Encountered a few issues with the embedded experience when `container` was passed into the `HelloSign.open()` call. Recommend the following changes to improve in-page UX:
- Make the iFrame top-aligned rather than inline to prevent line spacing being applied to it
- Process parameters before `stringify`-ing to avoid errors due to circular nature of DOM elements
- Set height to 100% if `container` is supplied and `height` is not
- Set width to 100% if `container` is supplied