### PR TITLE
[DEV-4831] Create an alert in our embedded flows if the user tries to navigate off the page

### DIFF
--- a/src/embedded.js
+++ b/src/embedded.js
@@ -604,6 +604,20 @@ class HelloSign extends Emitter {
   }
 
   /**
+   * Starts the initialization timeout timerif the workflow
+   * is embedded signing.
+   *
+   * @private
+   */
+  _maybeStartInitTimeout() {
+    if (this._iFrameURL.href.includes('embeddedSign')) {
+      // Start the initialization timeout because this is
+      // embedded signing.
+      this._startInitTimeout();
+    }
+  }
+
+  /**
    * @event HelloSign#error
    * @type {Object}
    * @property {string} signatureId

--- a/src/embedded.js
+++ b/src/embedded.js
@@ -525,6 +525,19 @@ class HelloSign extends Emitter {
   }
 
   /**
+   * Sends a cancel request message to the app.
+   *
+   * @private
+   */
+  _sendCancelRequestMessage() {
+    debug.info('sending cancel request message');
+
+    this._sendMessage({
+      type: settings.messages.USER_CANCEL_REQUEST,
+    });
+  }
+
+  /**
    * Sends the configuration message to the app.
    *
    * @private
@@ -845,7 +858,7 @@ class HelloSign extends Emitter {
     if (elem.classList.contains(settings.classNames.MODAL_CLOSE_BTN)) {
       evt.preventDefault();
 
-      this._userDidCancelRequest();
+      this._sendCancelRequestMessage();
     }
   }
 

--- a/src/embedded.js
+++ b/src/embedded.js
@@ -893,7 +893,7 @@ class HelloSign extends Emitter {
    */
   _onBeforeUnload(evt) {
     if (this._isReady) {
-      if (!confirm('Are you sure you want to close this signature request?')) {
+      if (!confirm('Are you sure you want to close this signature request? You will lose your changes.')) {
         evt.preventDefault();
 
         // Chrome requires returnValue to be set.

--- a/src/embedded.js
+++ b/src/embedded.js
@@ -655,10 +655,10 @@ class HelloSign extends Emitter {
 
     this._isReady = true;
 
-    this.emit(settings.events.READY, payload);
-
     this._sendConfigurationMessage();
     this._clearInitTimeout();
+
+    this.emit(settings.events.READY, payload);
   }
 
   /**
@@ -893,6 +893,7 @@ class HelloSign extends Emitter {
    */
   _onBeforeUnload(evt) {
     if (this._isReady) {
+      /* eslint-disable-next-line no-restricted-globals */
       if (!confirm('Are you sure you want to close this signature request? You will lose your changes.')) {
         evt.preventDefault();
 

--- a/src/embedded.test.js
+++ b/src/embedded.test.js
@@ -82,6 +82,33 @@ describe('HelloSign', () => {
         expect(client.isOpen).toEqual(false);
       });
     });
+
+    describe('#isReady()', () => {
+      test('returns the ready state', (done) => {
+        client = new HelloSign({ clientId: mockClientId });
+
+        expect(client.isReady).toEqual(false);
+
+        client.once('open', () => {
+          mockPostMessage({
+            type: HelloSign.messages.APP_INITIALIZE,
+          });
+        });
+
+        client.once('ready', () => {
+          expect(client.isReady).toEqual(true);
+
+          client.close();
+        });
+
+        client.once('close', () => {
+          expect(client.isReady).toEqual(false);
+          done();
+        });
+
+        client.open(mockSignURL);
+      });
+    });
   });
 
   describe('methods', () => {
@@ -814,19 +841,6 @@ describe('HelloSign', () => {
         expect(closeBtn.length).toBe(1);
       });
 
-      test('closes the signature request if it does not initialize before the timeout', (done) => {
-        client = new HelloSign({ clientId: mockClientId });
-
-        client.open(mockRequestURL, {
-          timeout: 2000,
-        });
-
-        setTimeout(() => {
-          expect(client.isOpen).toBe(false);
-          done();
-        }, 3000);
-      });
-
       test('emits the "ready" event when app has initialized', (done) => {
         client = new HelloSign({ clientId: mockClientId });
 
@@ -882,19 +896,6 @@ describe('HelloSign', () => {
         const closeBtn = document.getElementsByClassName(settings.classNames.MODAL_CLOSE_BTN);
 
         expect(closeBtn.length).toBe(1);
-      });
-
-      test('closes the signature request if it does not initialize before the timeout', (done) => {
-        client = new HelloSign({ clientId: mockClientId });
-
-        client.open(mockTemplatetURL, {
-          timeout: 2000,
-        });
-
-        setTimeout(() => {
-          expect(client.isOpen).toBe(false);
-          done();
-        }, 3000);
       });
 
       test('emits the "ready" event when app has initialized', (done) => {

--- a/src/embedded.test.js
+++ b/src/embedded.test.js
@@ -154,7 +154,7 @@ describe('HelloSign', () => {
         client = new HelloSign();
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('client_id')).toBe(true);
           expect(url.searchParams.get('client_id')).toBe(mockClientId);
@@ -190,7 +190,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('debug')).toBe(true);
           expect(url.searchParams.get('debug')).toBe('1');
@@ -226,7 +226,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('final_button_text')).toBe(true);
           expect(url.searchParams.get('final_button_text')).toBe('Send');
@@ -252,7 +252,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('hide_header')).toBe(true);
           expect(url.searchParams.get('hide_header')).toBe('true');
@@ -268,7 +268,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('js_version')).toBe(true);
           expect(url.searchParams.get('js_version')).toBe(pkg.version);
@@ -302,7 +302,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('user_culture')).toBe(true);
           expect(url.searchParams.get('user_culture')).toBe(defaults.locale);
@@ -316,7 +316,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('user_culture')).toBe(true);
           expect(url.searchParams.get('user_culture')).toBe('zh_CN');
@@ -332,7 +332,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('parent_url')).toBe(true);
           expect(url.searchParams.get('parent_url')).toBe(document.location.href);
@@ -356,7 +356,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('redirect_url')).toBe(true);
           expect(url.searchParams.get('redirect_url')).toBe('http://example.com/');
@@ -382,7 +382,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('requester')).toBe(true);
           expect(url.searchParams.get('requester')).toBe('alice@example.com');
@@ -408,7 +408,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('skip_domain_verification')).toBe(true);
           expect(url.searchParams.get('skip_domain_verification')).toBe('0');
@@ -422,7 +422,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('skip_domain_verification')).toBe(true);
           expect(url.searchParams.get('skip_domain_verification')).toBe('1');
@@ -448,7 +448,7 @@ describe('HelloSign', () => {
         client = new HelloSign({ clientId: mockClientId });
 
         client.on(HelloSign.events.OPEN, (data) => {
-          const url = new URL(data.iFrameUrl);
+          const url = new URL(data.url);
 
           expect(url.searchParams.has('white_labeling_options')).toBe(true);
           expect(url.searchParams.get('white_labeling_options')).toBe(JSON.stringify({ foo: 'bar' }));
@@ -605,17 +605,13 @@ describe('HelloSign', () => {
       test('emits the "ready" event when app has initialized', (done) => {
         client = new HelloSign({ clientId: mockClientId });
 
-        client.once(HelloSign.events.READY, (data) => {
-          expect(data.signatureId).toBe(mockSignatureId);
+        client.once(HelloSign.events.READY, () => {
           done();
         });
 
         client.once('open', () => {
           mockPostMessage({
             type: HelloSign.messages.APP_INITIALIZE,
-            payload: {
-              signatureId: mockSignatureId,
-            },
           });
         });
 
@@ -818,6 +814,35 @@ describe('HelloSign', () => {
         expect(closeBtn.length).toBe(1);
       });
 
+      test('closes the signature request if it does not initialize before the timeout', (done) => {
+        client = new HelloSign({ clientId: mockClientId });
+
+        client.open(mockRequestURL, {
+          timeout: 2000,
+        });
+
+        setTimeout(() => {
+          expect(client.isOpen).toBe(false);
+          done();
+        }, 3000);
+      });
+
+      test('emits the "ready" event when app has initialized', (done) => {
+        client = new HelloSign({ clientId: mockClientId });
+
+        client.once(HelloSign.events.READY, () => {
+          done();
+        });
+
+        client.once('open', () => {
+          mockPostMessage({
+            type: HelloSign.messages.APP_INITIALIZE,
+          });
+        });
+
+        client.open(mockRequestURL);
+      });
+
       test('emits the "send" event when the signature request has been sent', (done) => {
         client = new HelloSign({ clientId: mockClientId });
 
@@ -857,6 +882,35 @@ describe('HelloSign', () => {
         const closeBtn = document.getElementsByClassName(settings.classNames.MODAL_CLOSE_BTN);
 
         expect(closeBtn.length).toBe(1);
+      });
+
+      test('closes the signature request if it does not initialize before the timeout', (done) => {
+        client = new HelloSign({ clientId: mockClientId });
+
+        client.open(mockTemplatetURL, {
+          timeout: 2000,
+        });
+
+        setTimeout(() => {
+          expect(client.isOpen).toBe(false);
+          done();
+        }, 3000);
+      });
+
+      test('emits the "ready" event when app has initialized', (done) => {
+        client = new HelloSign({ clientId: mockClientId });
+
+        client.once(HelloSign.events.READY, () => {
+          done();
+        });
+
+        client.once('open', () => {
+          mockPostMessage({
+            type: HelloSign.messages.APP_INITIALIZE,
+          });
+        });
+
+        client.open(mockTemplatetURL);
       });
 
       test('sends the "createTemplate" event when the signature request template has been created', (done) => {

--- a/src/settings.js
+++ b/src/settings.js
@@ -86,23 +86,10 @@ const messages = {
   USER_SIGN_REQUEST: 'hellosign:userSignRequest',
 };
 
-/**
- * Embedded signature request types.
- *
- * @enum {string}
- * @readonly
- */
-const types = {
-  EMBEDDED_SIGN: 'embeddedSign',
-  EMBEDDED_TEMPLATE: 'embeddedTemplate',
-  EMBEDDED_REQUEST: 'embeddedRequest',
-};
-
 export default {
   classNames,
   events,
   iframe,
   locales,
   messages,
-  types,
 };

--- a/src/settings.test.js
+++ b/src/settings.test.js
@@ -21,8 +21,4 @@ describe('settings', () => {
   test('exports messages', () => {
     expect(settings.messages).toBeDefined();
   });
-
-  test('exports types', () => {
-    expect(settings.types).toBeDefined();
-  });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,1 +1,2 @@
 window.alert = () => {};
+window.confirm = () => {};


### PR DESCRIPTION
Squash message title:
```
feat(DEV-4831): Adds close confirmation dialog message when `beforeunload` fires.
```

Squash message body:
```
Also:
* Now accepts initialization events from Editor app (embedded requesting and templating), however these will have no affect on the initialization timeout. 
* Adds `isReady` getter property to Embedded instances.
```