### PR TITLE
feat: Drop support for es-MX locale

### DIFF
--- a/src/embedded.js
+++ b/src/embedded.js
@@ -261,6 +261,10 @@ class HelloSign extends Emitter {
   _applyLocale(params) {
     const val = this._config.locale;
 
+    if (val === 'es-MX') {
+      console.warn('Locale "es-MX" is no longer supported. Use es-LA instead.');
+    }
+
     // If "locale" is not defined, then the "user_culture"
     // param is not sent to the app. This tells the app to
     // try use the user's default browser language, if it

--- a/src/settings.js
+++ b/src/settings.js
@@ -59,7 +59,6 @@ const locales = {
   EN_US: 'en-US', // English (United States)
   ES_LA: 'es-LA', // Spanish (Latin America)
   ES_ES: 'es-ES', // Spanish (Spain)
-  ES_MX: 'es-MX', // Spanish (Mexico)
   FR_FR: 'fr-FR', // French (France)
   ID_ID: 'id-ID', // Indonesian (Indonesia)
   IT_IT: 'it-IT', // Italian (Italy)
@@ -76,6 +75,9 @@ const locales = {
   UK_UA: 'uk-UA', // Ukrainian (Ukraine)
   ZH_CN: 'zh-CN', // Chinese (Simplified) (China)
   ZH_TW: 'zh-TW', // Chinese (Taiwan)
+
+  // No longer supported, use es-LA instead.
+  // ES_MX: 'es-MX', // Spanish (Mexico)
 };
 
 /**


### PR DESCRIPTION
Our backend has not supported it for some time. Use es-LA instead.